### PR TITLE
OpenSSL::PKey::RSA#n= is deprecated because of OpenSSL 1.1.0 changes

### DIFF
--- a/lib/lastpass/parser.rb
+++ b/lib/lastpass/parser.rb
@@ -100,14 +100,25 @@ module LastPass
             asn1_encoded_key = OpenSSL::ASN1.decode asn1_encoded_all.value[2].value
 
             rsa_key = OpenSSL::PKey::RSA.new
-            rsa_key.n = asn1_encoded_key.value[1].value
-            rsa_key.e = asn1_encoded_key.value[2].value
-            rsa_key.d = asn1_encoded_key.value[3].value
-            rsa_key.p = asn1_encoded_key.value[4].value
-            rsa_key.q = asn1_encoded_key.value[5].value
-            rsa_key.dmp1 = asn1_encoded_key.value[6].value
-            rsa_key.dmq1 = asn1_encoded_key.value[7].value
-            rsa_key.iqmp = asn1_encoded_key.value[8].value
+            if rsa_key.respond_to? :set_key
+                rsa_key.set_key(asn1_encoded_key.value[1].value,
+                                asn1_encoded_key.value[2].value,
+                                asn1_encoded_key.value[3].value)
+                rsa_key.set_factors(asn1_encoded_key.value[4].value,
+                                    asn1_encoded_key.value[5].value)
+                rsa_key.set_crt_params(asn1_encoded_key.value[6].value,
+                                       asn1_encoded_key.value[7].value,
+                                       asn1_encoded_key.value[8].value)
+            else
+                rsa_key.n = asn1_encoded_key.value[1].value
+                rsa_key.e = asn1_encoded_key.value[2].value
+                rsa_key.d = asn1_encoded_key.value[3].value
+                rsa_key.p = asn1_encoded_key.value[4].value
+                rsa_key.q = asn1_encoded_key.value[5].value
+                rsa_key.dmp1 = asn1_encoded_key.value[6].value
+                rsa_key.dmq1 = asn1_encoded_key.value[7].value
+                rsa_key.iqmp = asn1_encoded_key.value[8].value
+            end
 
             rsa_key
         end


### PR DESCRIPTION
Do the same as in https://github.com/nov/json-jwt/commit/aa09a07e4b3939d7a9025ba9db97a861dc0c0817.

Before this change, `bundle exec rake spec` fails for ruby versions >= 2.4.0 with the following error:
```
Failures:

  1) LastPass::Parser.parse_private_key parses private key
     Failure/Error: rsa_key.n = asn1_encoded_key.value[1].value

     NoMethodError:
       undefined method `n=' for #<OpenSSL::PKey::RSA:0x007fe089380948>
       Did you mean?  n
     # ./lib/lastpass/parser.rb:103:in `parse_private_key'
     # ./spec/parser_spec.rb:119:in `block (3 levels) in <top (required)>'
     # ./spec/parser_spec.rb:123:in `block (3 levels) in <top (required)>'
```

After this change, the specs succeed.